### PR TITLE
Prevent running pre-commit on empty set of modified files in converter

### DIFF
--- a/definition_tooling/converter/converter.py
+++ b/definition_tooling/converter/converter.py
@@ -238,7 +238,8 @@ def convert_data_product_definitions(src: Path, dest: Path) -> bool:
                 print(f"Skipping {out_file}")
 
     # Run hooks on all modified files at once to save overhead from subprocess
-    run_pre_commit_hooks_on_files(modified_files)
+    if modified_files:
+        run_pre_commit_hooks_on_files(modified_files)
 
     return should_fail_hook
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ioxio-data-product-definition-tooling"
-version = "0.1.0"
+version = "0.1.1"
 description = "IOXIO Data Product Definition Tooling"
 authors = ["IOXIO Ltd"]
 license = "BSD-3-Clause"


### PR DESCRIPTION
In some cases it was possible the converter tried to run pre-commit on an empty set of files.