### PR TITLE
Automatically generate summary and description for a route

### DIFF
--- a/definition_tooling/converter/converter.py
+++ b/definition_tooling/converter/converter.py
@@ -76,13 +76,6 @@ class DataProductDefinition(BaseModel):
     response: Type[BaseModel]
     title: str
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-        if self.title:
-            if not self.description:
-                self.description = self.title
-
     @validator("error_responses")
     def validate_error_responses(cls, v: Dict[ERROR_CODE, ErrorModel]):
         status_codes = set(v.keys())

--- a/definition_tooling/converter/tests/__snapshots__/test_converter/test_air_quality.json
+++ b/definition_tooling/converter/tests/__snapshots__/test_converter/test_air_quality.json
@@ -262,7 +262,7 @@
   "paths": {
     "/AirQuality/Current": {
       "post": {
-        "description": "Current air quality",
+        "description": "Data Product for current air quality index",
         "operationId": "request_AirQuality_Current",
         "parameters": [
           {

--- a/definition_tooling/converter/tests/__snapshots__/test_converter/test_company_basic_info_errors.json
+++ b/definition_tooling/converter/tests/__snapshots__/test_converter/test_company_basic_info_errors.json
@@ -208,15 +208,15 @@
     }
   },
   "info": {
-    "description": "Data Product for basic company info",
-    "title": "Basic Company Info",
+    "description": "Legal information about a company such as registration address",
+    "title": "Information about a company",
     "version": "1.0.0"
   },
   "openapi": "3.0.2",
   "paths": {
     "/Company/BasicInfo": {
       "post": {
-        "description": "Information about the company",
+        "description": "Legal information about a company such as registration address",
         "operationId": "request_Company_BasicInfo",
         "parameters": [
           {
@@ -375,7 +375,7 @@
             "description": "Additional Response"
           }
         },
-        "summary": "Basic Company Info"
+        "summary": "Information about a company"
       }
     }
   }

--- a/definition_tooling/converter/tests/__snapshots__/test_converter/test_current_weather_required_headers.json
+++ b/definition_tooling/converter/tests/__snapshots__/test_converter/test_current_weather_required_headers.json
@@ -267,15 +267,15 @@
     }
   },
   "info": {
-    "description": "Data Product for current weather with metric units",
-    "title": "Current Weather (Metric)",
+    "description": "Current weather in a given location in metric units",
+    "title": "Current weather in a given location",
     "version": "1.0.0"
   },
   "openapi": "3.0.2",
   "paths": {
     "/Weather/Current/Metric": {
       "post": {
-        "description": "Current weather in metric units",
+        "description": "Current weather in a given location in metric units",
         "operationId": "request_Weather_Current_Metric",
         "parameters": [
           {
@@ -434,7 +434,7 @@
             "description": "Additional Response"
           }
         },
-        "summary": "Current Weather (Metric)"
+        "summary": "Current weather in a given location"
       }
     }
   }

--- a/definition_tooling/converter/tests/data/AirQuality/Current.py
+++ b/definition_tooling/converter/tests/data/AirQuality/Current.py
@@ -51,9 +51,8 @@ class CurrentAirQualityResponse(CamelCaseModel):
 
 
 DEFINITION = DataProductDefinition(
+    title="Air Quality Index",
     description="Data Product for current air quality index",
     request=CurrentAirQualityRequest,
     response=CurrentAirQualityResponse,
-    route_description="Current air quality",
-    summary="Air Quality Index",
 )

--- a/definition_tooling/converter/tests/data/Appliance/CoffeeBrewer.py
+++ b/definition_tooling/converter/tests/data/Appliance/CoffeeBrewer.py
@@ -39,9 +39,10 @@ class TeaPotError(CamelCaseModel):
 
 
 DEFINITION = DataProductDefinition(
+    title="Coffee brewer",
+    description="Coffee brewer",
     request=CoffeeBrewingRequest,
     response=CoffeeBrewingResponse,
-    summary="Coffee brewer",
     error_responses={
         418: TeaPotError,
     },

--- a/definition_tooling/converter/tests/data/Company/BasicInfo.py
+++ b/definition_tooling/converter/tests/data/Company/BasicInfo.py
@@ -39,11 +39,10 @@ class UnavailableForLegalReasonsResponse(CamelCaseModel):
 
 
 DEFINITION = DataProductDefinition(
-    description="Data Product for basic company info",
+    title="Information about a company",
+    description="Legal information about a company such as registration address",
     request=BasicCompanyInfoRequest,
     response=BasicCompanyInfoResponse,
-    route_description="Information about the company",
-    summary="Basic Company Info",
     error_responses={
         422: UnavailableForLegalReasonsResponse,
     },

--- a/definition_tooling/converter/tests/data/Weather/Current/Metric.py
+++ b/definition_tooling/converter/tests/data/Weather/Current/Metric.py
@@ -42,11 +42,10 @@ class CurrentWeatherMetricResponse(CamelCaseModel):
 
 
 DEFINITION = DataProductDefinition(
-    description="Data Product for current weather with metric units",
+    title="Current weather in a given location",
+    description="Current weather in a given location in metric units",
     request=CurrentWeatherMetricRequest,
     response=CurrentWeatherMetricResponse,
-    route_description="Current weather in metric units",
-    summary="Current Weather (Metric)",
     requires_authorization=True,
     requires_consent=True,
 )

--- a/definition_tooling/validator/core.py
+++ b/definition_tooling/validator/core.py
@@ -38,6 +38,10 @@ def validate_spec(spec: dict):
     if not spec.get("openapi", "").startswith("3"):
         raise err.UnsupportedVersion("Validator supports only OpenAPI 3.x specs")
 
+    for field in {"title", "description"}:
+        if not spec.get("info", {}).get(field):
+            raise err.MandatoryField(f"{field} is a required field")
+
     paths = spec.get("paths", {})
     if not paths:
         raise err.NoEndpointsDefined
@@ -52,6 +56,10 @@ def validate_spec(spec: dict):
         if methods != ["post"]:
             raise err.OnlyPostMethodAllowed
         post_route = path["post"]
+
+    for field in {"summary", "description"}:
+        if not post_route.get(field):
+            raise err.MandatoryField(f"{field} is a required field for POST route")
 
     component_schemas = spec.get("components", {}).get("schemas")
     if not component_schemas:

--- a/definition_tooling/validator/core.py
+++ b/definition_tooling/validator/core.py
@@ -40,7 +40,7 @@ def validate_spec(spec: dict):
 
     for field in {"title", "description"}:
         if not spec.get("info", {}).get(field):
-            raise err.MandatoryField(f"{field} is a required field")
+            raise err.MandatoryField(f'{field} is a required field in "info" section')
 
     paths = spec.get("paths", {})
     if not paths:

--- a/definition_tooling/validator/errors.py
+++ b/definition_tooling/validator/errors.py
@@ -35,6 +35,10 @@ class SchemaMissing(DefinitionError):
     pass
 
 
+class MandatoryField(DefinitionError):
+    pass
+
+
 class NoEndpointsDefined(DefinitionError):
     pass
 

--- a/definition_tooling/validator/tests/test_definitions.py
+++ b/definition_tooling/validator/tests/test_definitions.py
@@ -167,3 +167,21 @@ def test_http_errors_defined(tmp_path, code):
     spec = deepcopy(COMPANY_BASIC_INFO)
     spec["paths"]["/draft/Company/BasicInfo"]["post"]["responses"].pop(str(code), None)
     check_validation_error(tmp_path, spec, err.HTTPResponseIsMissing)
+
+
+def test_required_fields(tmp_path):
+    spec = deepcopy(COMPANY_BASIC_INFO)
+    del spec["info"]["description"]
+    check_validation_error(tmp_path, spec, err.MandatoryField)
+
+    spec = deepcopy(COMPANY_BASIC_INFO)
+    del spec["info"]["title"]
+    check_validation_error(tmp_path, spec, err.MandatoryField)
+
+    spec = deepcopy(COMPANY_BASIC_INFO)
+    del spec["paths"]["/draft/Company/BasicInfo"]["post"]["summary"]
+    check_validation_error(tmp_path, spec, err.MandatoryField)
+
+    spec = deepcopy(COMPANY_BASIC_INFO)
+    del spec["paths"]["/draft/Company/BasicInfo"]["post"]["description"]
+    check_validation_error(tmp_path, spec, err.MandatoryField)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ioxio-data-product-definition-tooling"
-version = "0.1.1"
+version = "0.2.0"
 description = "IOXIO Data Product Definition Tooling"
 authors = ["IOXIO Ltd"]
 license = "BSD-3-Clause"


### PR DESCRIPTION
- Make title and description mandatory for a python definition
- Generate summary and description for a route based on those fields
- Add extra validation for that