### PR TITLE
Add versions to definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ repos:
     rev: main # You probably want to lock this to a specific tag
     hooks:
       - id: data-product-definition-converter
-        files: "src/.*py$"
-        args: ["src", "dest"]
+        pass_filenames: false
+        args: ["src", "DataProducts"]
+        files: |
+          (?x)^(
+            DataProducts/.*json|
+            src/.*py
+          )$
+      - id: data-product-definition-validator
+        files: ".*?DataProducts/.*?json$"
+        args: ["./DataProducts"]
 ```

--- a/definition_tooling/converter/tests/__snapshots__/test_converter/test_teapot_deprecated.json
+++ b/definition_tooling/converter/tests/__snapshots__/test_converter/test_teapot_deprecated.json
@@ -244,7 +244,7 @@
   "info": {
     "description": "Coffee brewer",
     "title": "Coffee brewer",
-    "version": "1.0.0"
+    "version": "0.1.0"
   },
   "openapi": "3.0.2",
   "paths": {

--- a/definition_tooling/converter/tests/data/AirQuality/Current.py
+++ b/definition_tooling/converter/tests/data/AirQuality/Current.py
@@ -51,6 +51,7 @@ class CurrentAirQualityResponse(CamelCaseModel):
 
 
 DEFINITION = DataProductDefinition(
+    version="1.0.0",
     title="Air Quality Index",
     description="Data Product for current air quality index",
     request=CurrentAirQualityRequest,

--- a/definition_tooling/converter/tests/data/Appliance/CoffeeBrewer.py
+++ b/definition_tooling/converter/tests/data/Appliance/CoffeeBrewer.py
@@ -39,6 +39,7 @@ class TeaPotError(CamelCaseModel):
 
 
 DEFINITION = DataProductDefinition(
+    version="0.1.0",
     title="Coffee brewer",
     description="Coffee brewer",
     request=CoffeeBrewingRequest,

--- a/definition_tooling/converter/tests/data/Company/BasicInfo.py
+++ b/definition_tooling/converter/tests/data/Company/BasicInfo.py
@@ -39,6 +39,7 @@ class UnavailableForLegalReasonsResponse(CamelCaseModel):
 
 
 DEFINITION = DataProductDefinition(
+    version="1.0.0",
     title="Information about a company",
     description="Legal information about a company such as registration address",
     request=BasicCompanyInfoRequest,

--- a/definition_tooling/converter/tests/data/Weather/Current/Metric.py
+++ b/definition_tooling/converter/tests/data/Weather/Current/Metric.py
@@ -42,6 +42,7 @@ class CurrentWeatherMetricResponse(CamelCaseModel):
 
 
 DEFINITION = DataProductDefinition(
+    version="1.0.0",
     title="Current weather in a given location",
     description="Current weather in a given location in metric units",
     request=CurrentWeatherMetricRequest,

--- a/definition_tooling/validator/cli.py
+++ b/definition_tooling/validator/cli.py
@@ -39,7 +39,7 @@ def validate_specs(path: Path) -> int:
     for spec_path in path.glob("**/*.json"):
         print(f"File: {spec_path}")
         try:
-            DefinitionValidator(root_path=path, spec_path=spec_path).validate()
+            DefinitionValidator(spec_path=spec_path, root_path=path).validate()
         except Exception as exc:
             if isinstance(exc, ValidatorError):
                 detail = ": " + str(exc) if str(exc) else ""

--- a/definition_tooling/validator/cli.py
+++ b/definition_tooling/validator/cli.py
@@ -39,7 +39,7 @@ def validate_specs(path: Path) -> int:
     for spec_path in path.glob("**/*.json"):
         print(f"File: {spec_path}")
         try:
-            DefinitionValidator(spec_path).validate()
+            DefinitionValidator(root_path=path, spec_path=spec_path).validate()
         except Exception as exc:
             if isinstance(exc, ValidatorError):
                 detail = ": " + str(exc) if str(exc) else ""

--- a/definition_tooling/validator/core.py
+++ b/definition_tooling/validator/core.py
@@ -60,9 +60,6 @@ def validate_version(spec: dict, spec_path: Path, root_path: Path):
         if version >= Version.parse("0.1.0"):
             raise err.TooHighVersion
     else:
-        if version < Version.parse("0.1.0"):
-            raise err.TooLowVersion
-
         try:
             file_version = parse_version_without_patch(file_version_str)
         except ValueError:
@@ -72,6 +69,9 @@ def validate_version(spec: dict, spec_path: Path, root_path: Path):
             version.major, version.minor, 0, version.prerelease, version.build
         ):
             raise err.VersionMissmatch
+
+        if version < Version.parse("0.1.0"):
+            raise err.TooLowVersion
 
 
 def validate_spec(spec: dict, spec_path: Path, root_path: Path):

--- a/definition_tooling/validator/core.py
+++ b/definition_tooling/validator/core.py
@@ -2,8 +2,11 @@ import json
 from pathlib import Path
 from typing import Union
 
+from semver import Version
+
 from definition_tooling.api_errors import DATA_PRODUCT_ERRORS
 from definition_tooling.validator import errors as err
+from definition_tooling.validator.utils import parse_version_without_patch
 
 
 def validate_component_schema(spec: dict, components_schema: dict):
@@ -24,18 +27,67 @@ def validate_component_schema(spec: dict, components_schema: dict):
         raise err.SchemaMissing(f"Component schema is missing for {model_name}")
 
 
-def validate_spec(spec: dict):
+def validate_version(spec: dict, spec_path: Path, root_path: Path):
+    """
+    Validate version in definition and filename.
+
+    Definitions in "test/" and "draft/" namespaces should:
+    - have versions < 0.1.0
+    - not have any version in the filename
+
+    All other definitions should:
+    - have version >= 0.1.0
+    - have the _v{MAJOR}.{MINOR} number in the filename
+    - have versions that match the version in the filename
+
+    :param spec: OpenAPI spec
+    :param spec_path: Path to the actual definition
+    :param root_path: Path to the root of definitions
+    :raises VersionError: When there's a problem with the version number.
+    """
+    try:
+        version = Version.parse(spec["info"]["version"])
+    except (ValueError, TypeError, KeyError):
+        raise err.InvalidOrMissingVersion
+
+    test_definition = spec_path.is_relative_to(root_path / "test")
+    draft_definition = spec_path.is_relative_to(root_path / "draft")
+    _, __, file_version_str = spec_path.stem.partition("_v")
+
+    if test_definition or draft_definition:
+        if file_version_str:
+            raise err.UnexpectedVersionInFilename
+        if version >= Version.parse("0.1.0"):
+            raise err.TooHighVersion
+    else:
+        if version < Version.parse("0.1.0"):
+            raise err.TooLowVersion
+
+        try:
+            file_version = parse_version_without_patch(file_version_str)
+        except ValueError:
+            raise err.InvalidOrMissingVersionInFileName
+
+        if file_version != Version(
+            version.major, version.minor, 0, version.prerelease, version.build
+        ):
+            raise err.VersionMissmatch
+
+
+def validate_spec(spec: dict, spec_path: Path, root_path: Path):
     """
     Validate that OpenAPI spec looks like a data product definition. For example, that
     it only has one POST method defined.
 
     :param spec: OpenAPI spec
+    :param spec_path: Path to the actual definition
+    :param root_path: Path to the root of specs
     :raises OpenApiValidationError: When OpenAPI spec is incorrect
     """
     if "servers" in spec:
         raise err.ServersShouldNotBeDefined
 
-    if not spec.get("openapi", "").startswith("3"):
+    if not spec.get("openapi", "").startswith("3."):
         raise err.UnsupportedVersion("Validator supports only OpenAPI 3.x specs")
 
     for field in {"title", "description"}:
@@ -90,21 +142,28 @@ def validate_spec(spec: dict):
     if "x-authorization-provider" not in headers:
         raise err.AuthProviderHeaderMissing
 
+    validate_version(spec=spec, spec_path=spec_path, root_path=root_path)
+
 
 class DefinitionValidator:
-    def __init__(self, path: Union[str, Path]):
-        self.path = Path(path)
+    def __init__(
+        self,
+        spec_path: Union[str, Path],
+        root_path: Union[str, Path],
+    ):
+        self.root_path = Path(root_path)
+        self.spec_path = Path(spec_path)
 
     def validate(self):
         try:
-            spec = json.loads(self.path.read_text(encoding="utf8"))
+            spec = json.loads(self.spec_path.read_text(encoding="utf8"))
         except json.JSONDecodeError:
-            raise err.InvalidJSON(f"Incorrect JSON: {self.path}")
+            raise err.InvalidJSON(f"Incorrect JSON: {self.spec_path}")
         except Exception as e:
-            raise err.ValidatorError(f"Failed to validate {self.path}: {e}")
-        self.validate_spec(spec)
+            raise err.ValidatorError(f"Failed to validate {self.spec_path}: {e}")
+        self.validate_spec(spec, spec_path=self.spec_path, root_path=self.root_path)
 
     @classmethod
-    def validate_spec(cls, spec: dict):
+    def validate_spec(cls, spec: dict, spec_path: Path, root_path: Path):
         # it's moved to separate function to reduce indentation
-        return validate_spec(spec)
+        return validate_spec(spec, spec_path=spec_path, root_path=root_path)

--- a/definition_tooling/validator/errors.py
+++ b/definition_tooling/validator/errors.py
@@ -81,3 +81,31 @@ class SecurityShouldNotBeDefined(DefinitionError):
 
 class HTTPResponseIsMissing(DefinitionError):
     pass
+
+
+class VersionError(DefinitionError):
+    pass
+
+
+class InvalidOrMissingVersion(VersionError):
+    msg = '"version" in "info" is missing or not a valid semantic version'
+
+
+class UnexpectedVersionInFilename(VersionError):
+    msg = "Test or draft definition should not have version in filename"
+
+
+class TooHighVersion(VersionError):
+    msg = "Test and draft definition should have version < 0.1.0"
+
+
+class TooLowVersion(VersionError):
+    msg = "Definition (not test or draft) should have version >= 0.1.0"
+
+
+class InvalidOrMissingVersionInFileName(VersionError):
+    msg = "The version number in the filename is missing or has incorrect format"
+
+
+class VersionMissmatch(VersionError):
+    msg = "The versions in the definition and filename do not match"

--- a/definition_tooling/validator/tests/conftest.py
+++ b/definition_tooling/validator/tests/conftest.py
@@ -13,7 +13,7 @@ COMPANY_BASIC_INFO: dict = json.loads(
 @pytest.fixture
 def company_basic_info():
     """
-    Fixture that returns a deepcopy of the Company Basic information to use in tests.
+    Fixture that returns a deepcopy of the Company Basic Info to use in tests.
     The tests can freely modify it and corrupt it (easier than having multiple corrupt
     definitions in the repo).
 

--- a/definition_tooling/validator/tests/conftest.py
+++ b/definition_tooling/validator/tests/conftest.py
@@ -1,0 +1,22 @@
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+SPECS_ROOT_DIR = Path(__file__).absolute().parent / "data"
+COMPANY_BASIC_INFO: dict = json.loads(
+    (SPECS_ROOT_DIR / "CompanyBasicInfo.json").read_text(encoding="utf8")
+)
+
+
+@pytest.fixture
+def company_basic_info():
+    """
+    Fixture that returns a deepcopy of the Company Basic information to use in tests.
+    The tests can freely modify it and corrupt it (easier than having multiple corrupt
+    definitions in the repo).
+
+    For performance reasons we load it once from filesystem (outside the fixture).
+    """
+    return deepcopy(COMPANY_BASIC_INFO)

--- a/definition_tooling/validator/tests/data/CompanyBasicInfo.json
+++ b/definition_tooling/validator/tests/data/CompanyBasicInfo.json
@@ -6,7 +6,7 @@
     "version": "1.0.0"
   },
   "paths": {
-    "/draft/Company/BasicInfo": {
+    "/Company/BasicInfo": {
       "post": {
         "summary": "Basic Company Info",
         "description": "Information about the company",

--- a/definition_tooling/validator/tests/test_definition_versions.py
+++ b/definition_tooling/validator/tests/test_definition_versions.py
@@ -1,0 +1,145 @@
+import json
+
+import pytest
+
+from definition_tooling.validator import errors as err
+from definition_tooling.validator.core import DefinitionValidator
+
+
+@pytest.fixture()
+def spec(company_basic_info):
+    """
+    Make spec an alias of company_basic_info to shorten down the tests.
+    """
+    yield company_basic_info
+
+
+@pytest.fixture()
+def validate_definition(tmp_path):
+    def validate_definition_(file: str, spec: dict):
+        spec_path = tmp_path / f"{file}.json"
+        spec_path.parent.mkdir(parents=True)
+        spec_path.write_text(json.dumps(spec))
+        DefinitionValidator(spec_path=spec_path, root_path=tmp_path).validate()
+
+    return validate_definition_
+
+
+@pytest.fixture()
+def check_version_error(tmp_path):
+    def check_version_error_(file: str, spec: dict, exception):
+        spec_path = tmp_path / f"{file}.json"
+        spec_path.parent.mkdir(parents=True)
+        spec_path.write_text(json.dumps(spec))
+        with pytest.raises(exception):
+            DefinitionValidator(spec_path=spec_path, root_path=tmp_path).validate()
+
+    return check_version_error_
+
+
+def test_missing_version(check_version_error, spec):
+    del spec["info"]["version"]
+    check_version_error("Company/BasicInfo_v1.0", spec, err.InvalidOrMissingVersion)
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        "1",
+        "1.0",
+        "1.0.0.0",
+        "-1.0.0",
+        "abc",
+        None,
+    ],
+)
+def test_invalid_version(check_version_error, spec, version: str):
+    spec["info"]["version"] = version
+    check_version_error("Company/BasicInfo_v1.0", spec, err.InvalidOrMissingVersion)
+
+
+@pytest.mark.parametrize(
+    "folder",
+    [
+        "draft",
+        "test",
+    ],
+)
+def test_version_in_filename_when_not_expected(check_version_error, spec, folder: str):
+    spec["info"]["version"] = "0.0.1"
+    check_version_error(
+        f"{folder}/Company/BasicInfo_v0.0", spec, err.UnexpectedVersionInFilename
+    )
+
+
+@pytest.mark.parametrize(
+    "folder,version",
+    [
+        ["draft", "1.0.0"],
+        ["draft", "0.1.0"],
+        ["test", "1.0.0"],
+        ["test", "0.1.0"],
+    ],
+)
+def test_too_high_version(check_version_error, spec, folder: str, version: str):
+    spec["info"]["version"] = version
+    check_version_error(f"{folder}/Company/BasicInfo", spec, err.TooHighVersion)
+
+
+@pytest.mark.parametrize(
+    "version,file_version",
+    [
+        ["0.0.1", "0.0"],
+        ["0.0.2", "0.0"],
+    ],
+)
+def test_too_low_version(check_version_error, spec, version: str, file_version: str):
+    spec["info"]["version"] = version
+    check_version_error(f"Company/BasicInfo_v{file_version}", spec, err.TooLowVersion)
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "Company/BasicInfo",
+        "Company/BasicInfo_vabc",
+        "Company/BasicInfo_v1",
+        "Company/BasicInfo_v1.1.0",
+        "Company/BasicInfo_v_1.0",
+        "Company/BasicInfo_1.1",
+    ],
+)
+def test_incorrect_filename_version(check_version_error, spec, filename: str):
+    check_version_error(filename, spec, err.InvalidOrMissingVersionInFileName)
+
+
+@pytest.mark.parametrize(
+    "version,file_version",
+    [
+        ["1.0.0", "1.1"],
+        ["1.1.0", "1.0"],
+        ["2.0.0", "1.0"],
+    ],
+)
+def test_version_missmatch(check_version_error, spec, version: str, file_version: str):
+    spec["info"]["version"] = version
+    check_version_error(
+        f"Company/BasicInfo_v{file_version}", spec, err.VersionMissmatch
+    )
+
+
+@pytest.mark.parametrize(
+    "version,filename",
+    [
+        ["0.1.0", "Company/BasicInfo_v0.1"],
+        ["0.1.1", "Company/BasicInfo_v0.1"],
+        ["0.1.2", "Company/BasicInfo_v0.1"],
+        ["1.0.0", "Company/BasicInfo_v1.0"],
+        ["1.1.0-beta", "Company/BasicInfo_v1.1-beta"],
+        ["1.1.0-beta.2", "Company/BasicInfo_v1.1-beta.2"],
+        ["1.1.0", "Company/BasicInfo_v1.1"],
+    ],
+)
+def test_valid_versions(validate_definition, spec, version: str, filename: str):
+    spec["info"]["version"] = version
+    validate_definition(filename, spec)

--- a/definition_tooling/validator/tests/test_definition_versions.py
+++ b/definition_tooling/validator/tests/test_definition_versions.py
@@ -131,6 +131,10 @@ def test_version_missmatch(check_version_error, spec, version: str, file_version
 @pytest.mark.parametrize(
     "version,filename",
     [
+        ["0.0.1", "test/Company/BasicInfo"],
+        ["0.0.2", "test/Company/BasicInfo"],
+        ["0.0.1", "draft/Company/BasicInfo"],
+        ["0.0.200", "draft/Company/BasicInfo"],
         ["0.1.0", "Company/BasicInfo_v0.1"],
         ["0.1.1", "Company/BasicInfo_v0.1"],
         ["0.1.2", "Company/BasicInfo_v0.1"],
@@ -138,6 +142,7 @@ def test_version_missmatch(check_version_error, spec, version: str, file_version
         ["1.1.0-beta", "Company/BasicInfo_v1.1-beta"],
         ["1.1.0-beta.2", "Company/BasicInfo_v1.1-beta.2"],
         ["1.1.0", "Company/BasicInfo_v1.1"],
+        ["12.34.56", "Company/BasicInfo_v12.34"],
     ],
 )
 def test_valid_versions(validate_definition, spec, version: str, filename: str):

--- a/definition_tooling/validator/tests/test_definitions.py
+++ b/definition_tooling/validator/tests/test_definitions.py
@@ -1,89 +1,79 @@
 import json
 from copy import deepcopy
-from pathlib import Path
 
 import pytest
 
 from definition_tooling.validator import errors as err
 from definition_tooling.validator.core import DefinitionValidator
 
-# Note: It's easier to get some 100% valid spec and corrupt it
-# instead of having multiple incorrect specs in the repo
 
-SPECS_ROOT_DIR = Path(__file__).absolute().parent / "data"
-COMPANY_BASIC_INFO: dict = json.loads(
-    (SPECS_ROOT_DIR / "CompanyBasicInfo.json").read_text(encoding="utf8")
-)
+@pytest.fixture()
+def spec(company_basic_info):
+    """
+    Make spec an alias of company_basic_info to shorten down the tests.
+    """
+    yield company_basic_info
 
 
 def check_validation_error(tmp_path, spec: dict, exception):
-    spec_path = tmp_path / "spec.json"
+    spec_path = tmp_path / "BasicInfo_v1.0.json"
     spec_path.write_text(json.dumps(spec))
     with pytest.raises(exception):
-        DefinitionValidator(spec_path).validate()
+        DefinitionValidator(spec_path=spec_path, root_path=tmp_path).validate()
 
 
 @pytest.mark.parametrize("method", ["get", "put", "delete"])
-def test_standards_has_non_post_method(method, tmp_path):
-    spec = deepcopy(COMPANY_BASIC_INFO)
-    spec["paths"]["/draft/Company/BasicInfo"][method] = {
+def test_standards_has_non_post_method(method, tmp_path, spec):
+    spec["paths"]["/Company/BasicInfo"][method] = {
         "description": "Method which should not exist"
     }
     check_validation_error(tmp_path, spec, err.OnlyPostMethodAllowed)
 
 
-def test_post_method_is_missing(tmp_path):
-    spec = deepcopy(COMPANY_BASIC_INFO)
-    del spec["paths"]["/draft/Company/BasicInfo"]["post"]
+def test_post_method_is_missing(tmp_path, spec):
+    del spec["paths"]["/Company/BasicInfo"]["post"]
     check_validation_error(tmp_path, spec, err.PostMethodIsMissing)
 
 
-def test_many_endpoints(tmp_path):
-    spec = deepcopy(COMPANY_BASIC_INFO)
+def test_many_endpoints(tmp_path, spec):
     spec["paths"]["/pets"] = {"post": {"description": "Pet store, why not?"}}
     check_validation_error(tmp_path, spec, err.OnlyOneEndpointAllowed)
 
 
-def test_no_endpoints(tmp_path):
-    spec = deepcopy(COMPANY_BASIC_INFO)
+def test_no_endpoints(tmp_path, spec):
     del spec["paths"]
     check_validation_error(tmp_path, spec, err.NoEndpointsDefined)
 
 
-def test_missing_field_body_is_fine(tmp_path):
-    spec = deepcopy(COMPANY_BASIC_INFO)
-    del spec["paths"]["/draft/Company/BasicInfo"]["post"]["requestBody"]
-    spec_path = tmp_path / "spec.json"
+def test_missing_field_body_is_fine(tmp_path, spec):
+    del spec["paths"]["/Company/BasicInfo"]["post"]["requestBody"]
+    spec_path = tmp_path / "BasicInfo_v1.0.json"
     spec_path.write_text(json.dumps(spec))
-    DefinitionValidator(spec_path).validate()
+    DefinitionValidator(spec_path=spec_path, root_path=tmp_path).validate()
 
 
-def test_missing_200_response(tmp_path):
-    spec = deepcopy(COMPANY_BASIC_INFO)
-    del spec["paths"]["/draft/Company/BasicInfo"]["post"]["responses"]["200"]
+def test_missing_200_response(tmp_path, spec):
+    del spec["paths"]["/Company/BasicInfo"]["post"]["responses"]["200"]
     check_validation_error(tmp_path, spec, err.ResponseBodyMissing)
 
 
-def test_wrong_content_type_of_request_body(tmp_path):
-    spec = deepcopy(COMPANY_BASIC_INFO)
-    request_body = spec["paths"]["/draft/Company/BasicInfo"]["post"]["requestBody"]
+def test_wrong_content_type_of_request_body(tmp_path, spec):
+    request_body = spec["paths"]["/Company/BasicInfo"]["post"]["requestBody"]
     schema = deepcopy(request_body["content"]["application/json"])
     request_body["content"]["text/plan"] = schema
     del request_body["content"]["application/json"]
     check_validation_error(tmp_path, spec, err.WrongContentType)
 
 
-def test_wrong_content_type_of_response(tmp_path):
-    spec = deepcopy(COMPANY_BASIC_INFO)
-    response = spec["paths"]["/draft/Company/BasicInfo"]["post"]["responses"]["200"]
+def test_wrong_content_type_of_response(tmp_path, spec):
+    response = spec["paths"]["/Company/BasicInfo"]["post"]["responses"]["200"]
     schema = deepcopy(response["content"]["application/json"])
     response["content"]["text/plan"] = schema
     del response["content"]["application/json"]
     check_validation_error(tmp_path, spec, err.WrongContentType)
 
 
-def test_component_schema_is_missing(tmp_path):
-    spec = deepcopy(COMPANY_BASIC_INFO)
+def test_component_schema_is_missing(tmp_path, spec):
     del spec["components"]["schemas"]
     check_validation_error(tmp_path, spec, err.SchemaMissing)
 
@@ -91,61 +81,52 @@ def test_component_schema_is_missing(tmp_path):
 @pytest.mark.parametrize(
     "model_name", ["BasicCompanyInfoRequest", "BasicCompanyInfoResponse"]
 )
-def test_component_is_missing(model_name, tmp_path):
-    spec = deepcopy(COMPANY_BASIC_INFO)
+def test_component_is_missing(model_name, tmp_path, spec):
     del spec["components"]["schemas"][model_name]
     check_validation_error(tmp_path, spec, err.SchemaMissing)
 
 
-def test_non_existing_component_defined_in_body(tmp_path):
-    spec = deepcopy(COMPANY_BASIC_INFO)
-    body = spec["paths"]["/draft/Company/BasicInfo"]["post"]["requestBody"]
+def test_non_existing_component_defined_in_body(tmp_path, spec):
+    body = spec["paths"]["/Company/BasicInfo"]["post"]["requestBody"]
     body["content"]["application/json"]["schema"]["$ref"] += "blah"
     check_validation_error(tmp_path, spec, err.SchemaMissing)
 
 
-def test_non_existing_component_defined_in_response(tmp_path):
-    spec = deepcopy(COMPANY_BASIC_INFO)
-    resp_200 = spec["paths"]["/draft/Company/BasicInfo"]["post"]["responses"]["200"]
+def test_non_existing_component_defined_in_response(tmp_path, spec):
+    resp_200 = spec["paths"]["/Company/BasicInfo"]["post"]["responses"]["200"]
     resp_200["content"]["application/json"]["schema"]["$ref"] += "blah"
     check_validation_error(tmp_path, spec, err.SchemaMissing)
 
 
-def test_auth_header_is_missing(tmp_path):
-    spec = deepcopy(COMPANY_BASIC_INFO)
+def test_auth_header_is_missing(tmp_path, spec):
     x_app_provider_header = {
         "schema": {"type": "string"},
         "in": "header",
         "name": "X-Authorization-Provider",
         "description": "Provider domain",
     }
-    spec["paths"]["/draft/Company/BasicInfo"]["post"]["parameters"] = [
-        x_app_provider_header
-    ]
+    spec["paths"]["/Company/BasicInfo"]["post"]["parameters"] = [x_app_provider_header]
     check_validation_error(tmp_path, spec, err.AuthorizationHeaderMissing)
 
 
-def test_auth_provider_header_is_missing(tmp_path):
-    spec = deepcopy(COMPANY_BASIC_INFO)
+def test_auth_provider_header_is_missing(tmp_path, spec):
     auth_header = {
         "schema": {"type": "string"},
         "in": "header",
         "name": "Authorization",
         "description": "User bearer token",
     }
-    spec["paths"]["/draft/Company/BasicInfo"]["post"]["parameters"] = [auth_header]
+    spec["paths"]["/Company/BasicInfo"]["post"]["parameters"] = [auth_header]
     check_validation_error(tmp_path, spec, err.AuthProviderHeaderMissing)
 
 
-def test_servers_are_defined(tmp_path):
-    spec = deepcopy(COMPANY_BASIC_INFO)
+def test_servers_are_defined(tmp_path, spec):
     spec["servers"] = [{"url": "http://example.com"}]
     check_validation_error(tmp_path, spec, err.ServersShouldNotBeDefined)
 
 
-def test_security_is_defined(tmp_path):
-    spec = deepcopy(COMPANY_BASIC_INFO)
-    spec["paths"]["/draft/Company/BasicInfo"]["post"]["security"] = {}
+def test_security_is_defined(tmp_path, spec):
+    spec["paths"]["/Company/BasicInfo"]["post"]["security"] = {}
     check_validation_error(tmp_path, spec, err.SecurityShouldNotBeDefined)
 
 
@@ -153,35 +134,33 @@ def test_loading_non_json_file(tmp_path):
     spec_path = tmp_path / "spec.json"
     spec_path.write_text("weirdo content")
     with pytest.raises(err.InvalidJSON):
-        DefinitionValidator(spec_path).validate()
+        DefinitionValidator(spec_path=spec_path, root_path=spec_path.parent).validate()
 
 
-def test_loading_unsupported_version(tmp_path):
-    spec = deepcopy(COMPANY_BASIC_INFO)
+def test_loading_unsupported_version(tmp_path, spec):
     spec["openapi"] = "999.999.999"
     check_validation_error(tmp_path, spec, err.UnsupportedVersion)
 
 
 @pytest.mark.parametrize("code", [401, 403, 404, 422, 444, 502, 503, 504, 550])
-def test_http_errors_defined(tmp_path, code):
-    spec = deepcopy(COMPANY_BASIC_INFO)
-    spec["paths"]["/draft/Company/BasicInfo"]["post"]["responses"].pop(str(code), None)
+def test_http_errors_defined(tmp_path, code, spec):
+    spec["paths"]["/Company/BasicInfo"]["post"]["responses"].pop(str(code), None)
     check_validation_error(tmp_path, spec, err.HTTPResponseIsMissing)
 
 
-def test_required_fields(tmp_path):
-    spec = deepcopy(COMPANY_BASIC_INFO)
+def test_required_fields(tmp_path, company_basic_info):
+    spec = deepcopy(company_basic_info)
     del spec["info"]["description"]
     check_validation_error(tmp_path, spec, err.MandatoryField)
 
-    spec = deepcopy(COMPANY_BASIC_INFO)
+    spec = deepcopy(company_basic_info)
     del spec["info"]["title"]
     check_validation_error(tmp_path, spec, err.MandatoryField)
 
-    spec = deepcopy(COMPANY_BASIC_INFO)
-    del spec["paths"]["/draft/Company/BasicInfo"]["post"]["summary"]
+    spec = deepcopy(company_basic_info)
+    del spec["paths"]["/Company/BasicInfo"]["post"]["summary"]
     check_validation_error(tmp_path, spec, err.MandatoryField)
 
-    spec = deepcopy(COMPANY_BASIC_INFO)
-    del spec["paths"]["/draft/Company/BasicInfo"]["post"]["description"]
+    spec = deepcopy(company_basic_info)
+    del spec["paths"]["/Company/BasicInfo"]["post"]["description"]
     check_validation_error(tmp_path, spec, err.MandatoryField)

--- a/definition_tooling/validator/tests/test_utils.py
+++ b/definition_tooling/validator/tests/test_utils.py
@@ -1,0 +1,33 @@
+import pytest
+from semver import Version
+
+from definition_tooling.validator.utils import parse_version_without_patch
+
+
+@pytest.mark.parametrize(
+    "version_string,expected",
+    [
+        ["0.0", "0.0.0"],
+        ["0.1", "0.1.0"],
+        ["0.1-beta", "0.1.0-beta"],
+        ["0.1-beta.2", "0.1.0-beta.2"],
+        ["0.1-beta.2+build", "0.1.0-beta.2+build"],
+    ],
+)
+def test_parse_version_without_patch(version_string: str, expected: str):
+    assert parse_version_without_patch(version_string) == Version.parse(expected)
+
+
+@pytest.mark.parametrize(
+    "version_string",
+    [
+        "",
+        "0",
+        "1",
+        "a.b",
+        "1.1.1",
+    ],
+)
+def test_invalid_parse_version_without_patch(version_string):
+    with pytest.raises(ValueError):
+        parse_version_without_patch(version_string)

--- a/definition_tooling/validator/utils.py
+++ b/definition_tooling/validator/utils.py
@@ -1,0 +1,50 @@
+import re
+from typing import Any, Dict
+
+from semver import Version
+
+_MAJOR_MINOR_NO_PATCH_REGEX_TEMPLATE = r"""
+        ^
+        (?P<major>0|[1-9]\d*)
+        (?:
+            \.
+            (?P<minor>0|[1-9]\d*)
+        )
+        (?:-(?P<prerelease>
+            (?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)
+            (?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*
+        ))?
+        (?:\+(?P<build>
+            [0-9a-zA-Z-]+
+            (?:\.[0-9a-zA-Z-]+)*
+        ))?
+        $
+    """
+_MAJOR_MINOR_NO_PATCH_REGEX = re.compile(
+    _MAJOR_MINOR_NO_PATCH_REGEX_TEMPLATE.format(opt_patch=""),
+    re.VERBOSE,
+)
+
+
+def parse_version_without_patch(version: str) -> Version:
+    """
+    Parse a version string that has no PATCH to a Version.
+
+    :param version: version string
+    :return: A Version
+    :raise ValueError: If version is invalid
+
+    >>> parse_version_without_patch('1.0')
+    Version(major=1, minor=0, patch=0, prerelease=None, build=None)
+    >>> parse_version_without_patch('1.0-beta.2')
+    Version(major=1, minor=0, patch=0, prerelease='beta.2', build=None)
+    """
+
+    match = _MAJOR_MINOR_NO_PATCH_REGEX.match(version)
+    if match is None:
+        raise ValueError(f"{version} is not valid version string without patch")
+
+    matched_version_parts: Dict[str, Any] = match.groupdict()
+    matched_version_parts["patch"] = 0
+
+    return Version(**matched_version_parts)

--- a/poetry.lock
+++ b/poetry.lock
@@ -552,6 +552,17 @@ pygments = ">=2.6.0,<3.0.0"
 jupyter = ["ipywidgets (>=7.5.1,<8.0.0)"]
 
 [[package]]
+name = "semver"
+version = "3.0.1"
+description = "Python helper for Semantic Versioning (https://semver.org)"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "semver-3.0.1-py3-none-any.whl", hash = "sha256:2a23844ba1647362c7490fe3995a86e097bb590d16f0f32dfc383008f19e4cdf"},
+    {file = "semver-3.0.1.tar.gz", hash = "sha256:9ec78c5447883c67b97f98c3b6212796708191d22e4ad30f4570f840171cbce1"},
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.0.post1"
 description = "Tool to Detect Surrounding Shell"
@@ -665,4 +676,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9.0,<4"
-content-hash = "ad85f3e787e31bd3af3048f1e2e0960909b6700a17a04658c74f4f82d901663e"
+content-hash = "e263a2f6c96f46cea8ec2d86e95f4a14b35bc56bd7ab9d58f61e9b0294925802"

--- a/poetry.lock
+++ b/poetry.lock
@@ -121,20 +121,20 @@ test = ["flake8 (==3.7.8)", "hypothesis (==3.55.3)"]
 
 [[package]]
 name = "deepdiff"
-version = "6.3.0"
+version = "6.5.0"
 description = "Deep Difference and Search of any Python object/data. Recreate objects by adding adding deltas to each other."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "deepdiff-6.3.0-py3-none-any.whl", hash = "sha256:15838bd1cbd046ce15ed0c41e837cd04aff6b3e169c5e06fca69d7aa11615ceb"},
-    {file = "deepdiff-6.3.0.tar.gz", hash = "sha256:6a3bf1e7228ac5c71ca2ec43505ca0a743ff54ec77aa08d7db22de6bc7b2b644"},
+    {file = "deepdiff-6.5.0-py3-none-any.whl", hash = "sha256:acdc1651a3e802415e0337b7e1192df5cd7c17b72fbab480466fdd799b9a72e7"},
+    {file = "deepdiff-6.5.0.tar.gz", hash = "sha256:080b1359d6128f3f5f1738c6be3064f0ad9b0cc41994aa90a028065f6ad11f25"},
 ]
 
 [package.dependencies]
 ordered-set = ">=4.0.2,<4.2.0"
 
 [package.extras]
-cli = ["click (==8.1.3)", "pyyaml (==6.0)"]
+cli = ["click (==8.1.3)", "pyyaml (==6.0.1)"]
 optimize = ["orjson"]
 
 [[package]]
@@ -417,47 +417,47 @@ files = [
 
 [[package]]
 name = "pydantic"
-version = "1.10.8"
+version = "1.10.12"
 description = "Data validation and settings management using python type hints"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pydantic-1.10.8-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1243d28e9b05003a89d72e7915fdb26ffd1d39bdd39b00b7dbe4afae4b557f9d"},
-    {file = "pydantic-1.10.8-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c0ab53b609c11dfc0c060d94335993cc2b95b2150e25583bec37a49b2d6c6c3f"},
-    {file = "pydantic-1.10.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9613fadad06b4f3bc5db2653ce2f22e0de84a7c6c293909b48f6ed37b83c61f"},
-    {file = "pydantic-1.10.8-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:df7800cb1984d8f6e249351139667a8c50a379009271ee6236138a22a0c0f319"},
-    {file = "pydantic-1.10.8-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:0c6fafa0965b539d7aab0a673a046466d23b86e4b0e8019d25fd53f4df62c277"},
-    {file = "pydantic-1.10.8-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:e82d4566fcd527eae8b244fa952d99f2ca3172b7e97add0b43e2d97ee77f81ab"},
-    {file = "pydantic-1.10.8-cp310-cp310-win_amd64.whl", hash = "sha256:ab523c31e22943713d80d8d342d23b6f6ac4b792a1e54064a8d0cf78fd64e800"},
-    {file = "pydantic-1.10.8-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:666bdf6066bf6dbc107b30d034615d2627e2121506c555f73f90b54a463d1f33"},
-    {file = "pydantic-1.10.8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:35db5301b82e8661fa9c505c800d0990bc14e9f36f98932bb1d248c0ac5cada5"},
-    {file = "pydantic-1.10.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f90c1e29f447557e9e26afb1c4dbf8768a10cc676e3781b6a577841ade126b85"},
-    {file = "pydantic-1.10.8-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:93e766b4a8226e0708ef243e843105bf124e21331694367f95f4e3b4a92bbb3f"},
-    {file = "pydantic-1.10.8-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:88f195f582851e8db960b4a94c3e3ad25692c1c1539e2552f3df7a9e972ef60e"},
-    {file = "pydantic-1.10.8-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:34d327c81e68a1ecb52fe9c8d50c8a9b3e90d3c8ad991bfc8f953fb477d42fb4"},
-    {file = "pydantic-1.10.8-cp311-cp311-win_amd64.whl", hash = "sha256:d532bf00f381bd6bc62cabc7d1372096b75a33bc197a312b03f5838b4fb84edd"},
-    {file = "pydantic-1.10.8-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:7d5b8641c24886d764a74ec541d2fc2c7fb19f6da2a4001e6d580ba4a38f7878"},
-    {file = "pydantic-1.10.8-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b1f6cb446470b7ddf86c2e57cd119a24959af2b01e552f60705910663af09a4"},
-    {file = "pydantic-1.10.8-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c33b60054b2136aef8cf190cd4c52a3daa20b2263917c49adad20eaf381e823b"},
-    {file = "pydantic-1.10.8-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:1952526ba40b220b912cdc43c1c32bcf4a58e3f192fa313ee665916b26befb68"},
-    {file = "pydantic-1.10.8-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:bb14388ec45a7a0dc429e87def6396f9e73c8c77818c927b6a60706603d5f2ea"},
-    {file = "pydantic-1.10.8-cp37-cp37m-win_amd64.whl", hash = "sha256:16f8c3e33af1e9bb16c7a91fc7d5fa9fe27298e9f299cff6cb744d89d573d62c"},
-    {file = "pydantic-1.10.8-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1ced8375969673929809d7f36ad322934c35de4af3b5e5b09ec967c21f9f7887"},
-    {file = "pydantic-1.10.8-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:93e6bcfccbd831894a6a434b0aeb1947f9e70b7468f274154d03d71fabb1d7c6"},
-    {file = "pydantic-1.10.8-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:191ba419b605f897ede9892f6c56fb182f40a15d309ef0142212200a10af4c18"},
-    {file = "pydantic-1.10.8-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:052d8654cb65174d6f9490cc9b9a200083a82cf5c3c5d3985db765757eb3b375"},
-    {file = "pydantic-1.10.8-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:ceb6a23bf1ba4b837d0cfe378329ad3f351b5897c8d4914ce95b85fba96da5a1"},
-    {file = "pydantic-1.10.8-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6f2e754d5566f050954727c77f094e01793bcb5725b663bf628fa6743a5a9108"},
-    {file = "pydantic-1.10.8-cp38-cp38-win_amd64.whl", hash = "sha256:6a82d6cda82258efca32b40040228ecf43a548671cb174a1e81477195ed3ed56"},
-    {file = "pydantic-1.10.8-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3e59417ba8a17265e632af99cc5f35ec309de5980c440c255ab1ca3ae96a3e0e"},
-    {file = "pydantic-1.10.8-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:84d80219c3f8d4cad44575e18404099c76851bc924ce5ab1c4c8bb5e2a2227d0"},
-    {file = "pydantic-1.10.8-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2e4148e635994d57d834be1182a44bdb07dd867fa3c2d1b37002000646cc5459"},
-    {file = "pydantic-1.10.8-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:12f7b0bf8553e310e530e9f3a2f5734c68699f42218bf3568ef49cd9b0e44df4"},
-    {file = "pydantic-1.10.8-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:42aa0c4b5c3025483240a25b09f3c09a189481ddda2ea3a831a9d25f444e03c1"},
-    {file = "pydantic-1.10.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:17aef11cc1b997f9d574b91909fed40761e13fac438d72b81f902226a69dac01"},
-    {file = "pydantic-1.10.8-cp39-cp39-win_amd64.whl", hash = "sha256:66a703d1983c675a6e0fed8953b0971c44dba48a929a2000a493c3772eb61a5a"},
-    {file = "pydantic-1.10.8-py3-none-any.whl", hash = "sha256:7456eb22ed9aaa24ff3e7b4757da20d9e5ce2a81018c1b3ebd81a0b88a18f3b2"},
-    {file = "pydantic-1.10.8.tar.gz", hash = "sha256:1410275520dfa70effadf4c21811d755e7ef9bb1f1d077a21958153a92c8d9ca"},
+    {file = "pydantic-1.10.12-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a1fcb59f2f355ec350073af41d927bf83a63b50e640f4dbaa01053a28b7a7718"},
+    {file = "pydantic-1.10.12-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b7ccf02d7eb340b216ec33e53a3a629856afe1c6e0ef91d84a4e6f2fb2ca70fe"},
+    {file = "pydantic-1.10.12-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8fb2aa3ab3728d950bcc885a2e9eff6c8fc40bc0b7bb434e555c215491bcf48b"},
+    {file = "pydantic-1.10.12-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:771735dc43cf8383959dc9b90aa281f0b6092321ca98677c5fb6125a6f56d58d"},
+    {file = "pydantic-1.10.12-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:ca48477862372ac3770969b9d75f1bf66131d386dba79506c46d75e6b48c1e09"},
+    {file = "pydantic-1.10.12-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a5e7add47a5b5a40c49b3036d464e3c7802f8ae0d1e66035ea16aa5b7a3923ed"},
+    {file = "pydantic-1.10.12-cp310-cp310-win_amd64.whl", hash = "sha256:e4129b528c6baa99a429f97ce733fff478ec955513630e61b49804b6cf9b224a"},
+    {file = "pydantic-1.10.12-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b0d191db0f92dfcb1dec210ca244fdae5cbe918c6050b342d619c09d31eea0cc"},
+    {file = "pydantic-1.10.12-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:795e34e6cc065f8f498c89b894a3c6da294a936ee71e644e4bd44de048af1405"},
+    {file = "pydantic-1.10.12-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:69328e15cfda2c392da4e713443c7dbffa1505bc9d566e71e55abe14c97ddc62"},
+    {file = "pydantic-1.10.12-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2031de0967c279df0d8a1c72b4ffc411ecd06bac607a212892757db7462fc494"},
+    {file = "pydantic-1.10.12-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:ba5b2e6fe6ca2b7e013398bc7d7b170e21cce322d266ffcd57cca313e54fb246"},
+    {file = "pydantic-1.10.12-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:2a7bac939fa326db1ab741c9d7f44c565a1d1e80908b3797f7f81a4f86bc8d33"},
+    {file = "pydantic-1.10.12-cp311-cp311-win_amd64.whl", hash = "sha256:87afda5539d5140cb8ba9e8b8c8865cb5b1463924d38490d73d3ccfd80896b3f"},
+    {file = "pydantic-1.10.12-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:549a8e3d81df0a85226963611950b12d2d334f214436a19537b2efed61b7639a"},
+    {file = "pydantic-1.10.12-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:598da88dfa127b666852bef6d0d796573a8cf5009ffd62104094a4fe39599565"},
+    {file = "pydantic-1.10.12-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ba5c4a8552bff16c61882db58544116d021d0b31ee7c66958d14cf386a5b5350"},
+    {file = "pydantic-1.10.12-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:c79e6a11a07da7374f46970410b41d5e266f7f38f6a17a9c4823db80dadf4303"},
+    {file = "pydantic-1.10.12-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:ab26038b8375581dc832a63c948f261ae0aa21f1d34c1293469f135fa92972a5"},
+    {file = "pydantic-1.10.12-cp37-cp37m-win_amd64.whl", hash = "sha256:e0a16d274b588767602b7646fa05af2782576a6cf1022f4ba74cbb4db66f6ca8"},
+    {file = "pydantic-1.10.12-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6a9dfa722316f4acf4460afdf5d41d5246a80e249c7ff475c43a3a1e9d75cf62"},
+    {file = "pydantic-1.10.12-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:a73f489aebd0c2121ed974054cb2759af8a9f747de120acd2c3394cf84176ccb"},
+    {file = "pydantic-1.10.12-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b30bcb8cbfccfcf02acb8f1a261143fab622831d9c0989707e0e659f77a18e0"},
+    {file = "pydantic-1.10.12-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2fcfb5296d7877af406ba1547dfde9943b1256d8928732267e2653c26938cd9c"},
+    {file = "pydantic-1.10.12-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:2f9a6fab5f82ada41d56b0602606a5506aab165ca54e52bc4545028382ef1c5d"},
+    {file = "pydantic-1.10.12-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:dea7adcc33d5d105896401a1f37d56b47d443a2b2605ff8a969a0ed5543f7e33"},
+    {file = "pydantic-1.10.12-cp38-cp38-win_amd64.whl", hash = "sha256:1eb2085c13bce1612da8537b2d90f549c8cbb05c67e8f22854e201bde5d98a47"},
+    {file = "pydantic-1.10.12-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ef6c96b2baa2100ec91a4b428f80d8f28a3c9e53568219b6c298c1125572ebc6"},
+    {file = "pydantic-1.10.12-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6c076be61cd0177a8433c0adcb03475baf4ee91edf5a4e550161ad57fc90f523"},
+    {file = "pydantic-1.10.12-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2d5a58feb9a39f481eda4d5ca220aa8b9d4f21a41274760b9bc66bfd72595b86"},
+    {file = "pydantic-1.10.12-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e5f805d2d5d0a41633651a73fa4ecdd0b3d7a49de4ec3fadf062fe16501ddbf1"},
+    {file = "pydantic-1.10.12-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:1289c180abd4bd4555bb927c42ee42abc3aee02b0fb2d1223fb7c6e5bef87dbe"},
+    {file = "pydantic-1.10.12-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5d1197e462e0364906cbc19681605cb7c036f2475c899b6f296104ad42b9f5fb"},
+    {file = "pydantic-1.10.12-cp39-cp39-win_amd64.whl", hash = "sha256:fdbdd1d630195689f325c9ef1a12900524dceb503b00a987663ff4f58669b93d"},
+    {file = "pydantic-1.10.12-py3-none-any.whl", hash = "sha256:b749a43aa51e32839c9d71dc67eb1e4221bb04af1033a32e3923d46f9effa942"},
+    {file = "pydantic-1.10.12.tar.gz", hash = "sha256:0fe8a415cea8f340e7a9af9c54fc71a649b43e8ca3cc732986116b3cb135d303"},
 ]
 
 [package.dependencies]
@@ -676,4 +676,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9.0,<4"
-content-hash = "e263a2f6c96f46cea8ec2d86e95f4a14b35bc56bd7ab9d58f61e9b0294925802"
+content-hash = "6a71d8501a9e9f1d7ae0bb1c0387703adf1d4c041797b1710496e91564775840"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ioxio-data-product-definition-tooling"
-version = "0.2.0"
+version = "0.3.0"
 description = "IOXIO Data Product Definition Tooling"
 authors = ["IOXIO Ltd"]
 license = "BSD-3-Clause"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,10 @@ validate-definitions = "definition_tooling.validator.cli:cli"
 [tool.poetry.dependencies]
 python = ">=3.9.0,<4"
 typer = {extras = ["all"], version = "^0.9.0"}
-deepdiff = "^6.3.0"
+deepdiff = "^6.5.0"
 fastapi = "^0.98.0"
 stringcase = "^1.2.0"
-pydantic = {version = "^1.10.8", extras = ["email"]}
+pydantic = {version = "^1.10.12", extras = ["email"]}
 semver = "^3.0.1"
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ deepdiff = "^6.3.0"
 fastapi = "^0.98.0"
 stringcase = "^1.2.0"
 pydantic = {version = "^1.10.8", extras = ["email"]}
+semver = "^3.0.1"
 
 [tool.poetry.group.dev.dependencies]
 isort = "^5.12.0"


### PR DESCRIPTION
The `DataProductDefinition` now has a `version` field for the version number of the definition.

The validator ensures the filename has a version matching the version in the definition and that the test & draft definitions have no version in the filename and the version within the definition is 0.0.x. Definitions outside test & draft are on the other hand required to have a version in the filename (of the form `_v{MAJOR}.{MINOR}` with optional pre-release data) and it must match the full version (`{MAJOR}.{MINOR}.{PATCH}` with optional pre-release data) within the definition.