### PR TITLE
Stricter standardized error messages

### DIFF
--- a/definition_tooling/api_errors.py
+++ b/definition_tooling/api_errors.py
@@ -1,13 +1,15 @@
 """
-Predefined errors that the product gateway or productizers can return.
+Predefined errors that the product gateway or data sources can return.
 
 These errors can not be overridden by the data product definition itself.
 """
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class BaseApiError(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     __status__: int
 
     @classmethod

--- a/definition_tooling/api_errors.py
+++ b/definition_tooling/api_errors.py
@@ -4,7 +4,7 @@ Predefined errors that the product gateway or data sources can return.
 These errors can not be overridden by the data product definition itself.
 """
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr
 
 
 class BaseApiError(BaseModel):
@@ -18,8 +18,16 @@ class BaseApiError(BaseModel):
 
 
 class ApiError(BaseApiError):
-    type: str = Field(..., title="Error type", description="Error identifier")
-    message: str = Field(..., title="Error message", description="Error description")
+    type: StrictStr = Field(
+        ...,
+        title="Error type",
+        description="Error identifier",
+    )
+    message: StrictStr = Field(
+        ...,
+        title="Error message",
+        description="Error description",
+    )
 
 
 class ApiOrExternalError(BaseApiError):
@@ -49,7 +57,7 @@ class RateLimitExceeded(BaseApiError):
     """
 
     __status__ = 429
-    message: str = Field(
+    message: StrictStr = Field(
         "Rate limit exceeded",
         title="Error message",
         description="Error description",
@@ -62,7 +70,7 @@ class DataSourceNotFound(BaseApiError):
     """
 
     __status__ = 444
-    message: str = Field(
+    message: StrictStr = Field(
         "Data source not found",
         title="Error message",
         description="Error description",
@@ -87,7 +95,11 @@ class ServiceUnavailable(ApiOrExternalError):
     """
 
     __status__ = 503
-    message: str = Field("", title="Error message", description="Error description")
+    message: StrictStr = Field(
+        "",
+        title="Error message",
+        description="Error description",
+    )
 
 
 class GatewayTimeout(ApiOrExternalError):
@@ -96,7 +108,7 @@ class GatewayTimeout(ApiOrExternalError):
     """
 
     __status__ = 504
-    message: str = Field(
+    message: StrictStr = Field(
         "",
         title="Error message",
         description="Error description",
@@ -109,8 +121,8 @@ class DoesNotConformToDefinition(BaseApiError):
     """
 
     __status__ = 550
-    message: str = "Response from data source does not conform to definition"
-    data_source_status_code: int = Field(
+    message: StrictStr = "Response from data source does not conform to definition"
+    data_source_status_code: StrictInt = Field(
         ...,
         title="Data source status code",
         description="HTTP status code returned from the data source",

--- a/definition_tooling/converter/tests/__snapshots__/test_converter/test_air_quality.json
+++ b/definition_tooling/converter/tests/__snapshots__/test_converter/test_air_quality.json
@@ -2,6 +2,7 @@
   "components": {
     "schemas": {
       "BadGateway": {
+        "additionalProperties": false,
         "description": "This response is reserved by Product Gateway.",
         "properties": {},
         "title": "BadGateway",
@@ -79,6 +80,7 @@
         "type": "object"
       },
       "DataSourceError": {
+        "additionalProperties": false,
         "properties": {
           "message": {
             "description": "Error description",
@@ -99,6 +101,7 @@
         "type": "object"
       },
       "DataSourceNotFound": {
+        "additionalProperties": false,
         "description": "This response is reserved by Product Gateway.",
         "properties": {
           "message": {
@@ -112,6 +115,7 @@
         "type": "object"
       },
       "DoesNotConformToDefinition": {
+        "additionalProperties": false,
         "description": "This response is reserved by Product Gateway.",
         "properties": {
           "data_source_status_code": {
@@ -132,6 +136,7 @@
         "type": "object"
       },
       "Forbidden": {
+        "additionalProperties": false,
         "properties": {
           "message": {
             "description": "Error description",
@@ -152,6 +157,7 @@
         "type": "object"
       },
       "GatewayTimeout": {
+        "additionalProperties": false,
         "description": "This response is reserved by Product Gateway.",
         "properties": {
           "message": {
@@ -178,6 +184,7 @@
         "type": "object"
       },
       "NotFound": {
+        "additionalProperties": false,
         "properties": {
           "message": {
             "description": "Error description",
@@ -198,6 +205,7 @@
         "type": "object"
       },
       "RateLimitExceeded": {
+        "additionalProperties": false,
         "description": "This response is reserved by Product Gateway.",
         "properties": {
           "message": {
@@ -211,6 +219,7 @@
         "type": "object"
       },
       "ServiceUnavailable": {
+        "additionalProperties": false,
         "description": "This response is reserved by Product Gateway.",
         "properties": {
           "message": {
@@ -224,6 +233,7 @@
         "type": "object"
       },
       "Unauthorized": {
+        "additionalProperties": false,
         "properties": {
           "message": {
             "description": "Error description",

--- a/definition_tooling/converter/tests/__snapshots__/test_converter/test_company_basic_info_errors.json
+++ b/definition_tooling/converter/tests/__snapshots__/test_converter/test_company_basic_info_errors.json
@@ -2,6 +2,7 @@
   "components": {
     "schemas": {
       "BadGateway": {
+        "additionalProperties": false,
         "description": "This response is reserved by Product Gateway.",
         "properties": {},
         "title": "BadGateway",
@@ -65,6 +66,7 @@
         "type": "object"
       },
       "DataSourceError": {
+        "additionalProperties": false,
         "properties": {
           "message": {
             "description": "Error description",
@@ -85,6 +87,7 @@
         "type": "object"
       },
       "DataSourceNotFound": {
+        "additionalProperties": false,
         "description": "This response is reserved by Product Gateway.",
         "properties": {
           "message": {
@@ -98,6 +101,7 @@
         "type": "object"
       },
       "DoesNotConformToDefinition": {
+        "additionalProperties": false,
         "description": "This response is reserved by Product Gateway.",
         "properties": {
           "data_source_status_code": {
@@ -118,6 +122,7 @@
         "type": "object"
       },
       "Forbidden": {
+        "additionalProperties": false,
         "properties": {
           "message": {
             "description": "Error description",
@@ -138,6 +143,7 @@
         "type": "object"
       },
       "GatewayTimeout": {
+        "additionalProperties": false,
         "description": "This response is reserved by Product Gateway.",
         "properties": {
           "message": {
@@ -151,6 +157,7 @@
         "type": "object"
       },
       "NotFound": {
+        "additionalProperties": false,
         "properties": {
           "message": {
             "description": "Error description",
@@ -171,6 +178,7 @@
         "type": "object"
       },
       "RateLimitExceeded": {
+        "additionalProperties": false,
         "description": "This response is reserved by Product Gateway.",
         "properties": {
           "message": {
@@ -184,6 +192,7 @@
         "type": "object"
       },
       "ServiceUnavailable": {
+        "additionalProperties": false,
         "description": "This response is reserved by Product Gateway.",
         "properties": {
           "message": {
@@ -197,6 +206,7 @@
         "type": "object"
       },
       "Unauthorized": {
+        "additionalProperties": false,
         "properties": {
           "message": {
             "description": "Error description",

--- a/definition_tooling/converter/tests/__snapshots__/test_converter/test_current_weather_required_headers.json
+++ b/definition_tooling/converter/tests/__snapshots__/test_converter/test_current_weather_required_headers.json
@@ -2,6 +2,7 @@
   "components": {
     "schemas": {
       "BadGateway": {
+        "additionalProperties": false,
         "description": "This response is reserved by Product Gateway.",
         "properties": {},
         "title": "BadGateway",
@@ -96,6 +97,7 @@
         "type": "object"
       },
       "DataSourceError": {
+        "additionalProperties": false,
         "properties": {
           "message": {
             "description": "Error description",
@@ -116,6 +118,7 @@
         "type": "object"
       },
       "DataSourceNotFound": {
+        "additionalProperties": false,
         "description": "This response is reserved by Product Gateway.",
         "properties": {
           "message": {
@@ -129,6 +132,7 @@
         "type": "object"
       },
       "DoesNotConformToDefinition": {
+        "additionalProperties": false,
         "description": "This response is reserved by Product Gateway.",
         "properties": {
           "data_source_status_code": {
@@ -149,6 +153,7 @@
         "type": "object"
       },
       "Forbidden": {
+        "additionalProperties": false,
         "properties": {
           "message": {
             "description": "Error description",
@@ -169,6 +174,7 @@
         "type": "object"
       },
       "GatewayTimeout": {
+        "additionalProperties": false,
         "description": "This response is reserved by Product Gateway.",
         "properties": {
           "message": {
@@ -195,6 +201,7 @@
         "type": "object"
       },
       "NotFound": {
+        "additionalProperties": false,
         "properties": {
           "message": {
             "description": "Error description",
@@ -215,6 +222,7 @@
         "type": "object"
       },
       "RateLimitExceeded": {
+        "additionalProperties": false,
         "description": "This response is reserved by Product Gateway.",
         "properties": {
           "message": {
@@ -228,6 +236,7 @@
         "type": "object"
       },
       "ServiceUnavailable": {
+        "additionalProperties": false,
         "description": "This response is reserved by Product Gateway.",
         "properties": {
           "message": {
@@ -241,6 +250,7 @@
         "type": "object"
       },
       "Unauthorized": {
+        "additionalProperties": false,
         "properties": {
           "message": {
             "description": "Error description",

--- a/definition_tooling/converter/tests/__snapshots__/test_converter/test_teapot_deprecated.json
+++ b/definition_tooling/converter/tests/__snapshots__/test_converter/test_teapot_deprecated.json
@@ -2,6 +2,7 @@
   "components": {
     "schemas": {
       "BadGateway": {
+        "additionalProperties": false,
         "description": "This response is reserved by Product Gateway.",
         "properties": {},
         "title": "BadGateway",
@@ -41,6 +42,7 @@
         "type": "object"
       },
       "DataSourceError": {
+        "additionalProperties": false,
         "properties": {
           "message": {
             "description": "Error description",
@@ -61,6 +63,7 @@
         "type": "object"
       },
       "DataSourceNotFound": {
+        "additionalProperties": false,
         "description": "This response is reserved by Product Gateway.",
         "properties": {
           "message": {
@@ -74,6 +77,7 @@
         "type": "object"
       },
       "DoesNotConformToDefinition": {
+        "additionalProperties": false,
         "description": "This response is reserved by Product Gateway.",
         "properties": {
           "data_source_status_code": {
@@ -94,6 +98,7 @@
         "type": "object"
       },
       "Forbidden": {
+        "additionalProperties": false,
         "properties": {
           "message": {
             "description": "Error description",
@@ -114,6 +119,7 @@
         "type": "object"
       },
       "GatewayTimeout": {
+        "additionalProperties": false,
         "description": "This response is reserved by Product Gateway.",
         "properties": {
           "message": {
@@ -140,6 +146,7 @@
         "type": "object"
       },
       "NotFound": {
+        "additionalProperties": false,
         "properties": {
           "message": {
             "description": "Error description",
@@ -160,6 +167,7 @@
         "type": "object"
       },
       "RateLimitExceeded": {
+        "additionalProperties": false,
         "description": "This response is reserved by Product Gateway.",
         "properties": {
           "message": {
@@ -173,6 +181,7 @@
         "type": "object"
       },
       "ServiceUnavailable": {
+        "additionalProperties": false,
         "description": "This response is reserved by Product Gateway.",
         "properties": {
           "message": {
@@ -210,6 +219,7 @@
         "type": "object"
       },
       "Unauthorized": {
+        "additionalProperties": false,
         "properties": {
           "message": {
             "description": "Error description",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ioxio-data-product-definition-tooling"
-version = "0.13.0"
+version = "0.14.0"
 description = "IOXIO Data Product Definition Tooling"
 authors = ["IOXIO Ltd"]
 license = "BSD-3-Clause"


### PR DESCRIPTION
Forbids extra fields in all the models used for the default error message formats and also uses strict strings and strict integers for validation of those.